### PR TITLE
Fix unsupported last action on a friends item

### DIFF
--- a/app/src/main/java/com/yterletskyi/happyfriend/features/friends/ui/drag/FriendsTouchHelperCallback.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/features/friends/ui/drag/FriendsTouchHelperCallback.kt
@@ -62,7 +62,6 @@ class FriendsTouchHelperCallback(
         when (lastActionState) {
             ItemTouchHelper.ACTION_STATE_DRAG -> onDragEnded()
             ItemTouchHelper.ACTION_STATE_SWIPE -> onSwipeEnded()
-            else -> throw IllegalArgumentException("unsupported last action: $lastActionState")
         }
         lastActionState = ItemTouchHelper.ACTION_STATE_IDLE
     }


### PR DESCRIPTION
This fixes:
```
Process: com.yterletskyi.happy_friend, PID: 10056
    java.lang.IllegalArgumentException: unsupported last action: 0
        at com.yterletskyi.happyfriend.features.friends.ui.drag.FriendsTouchHelperCallback.clearView(FriendsTouchHelperCallback.kt:65)
```

The crash occurred when doing something with a FriendModelItem but not either dragging not swiping, probably something in between them.