### PR TITLE
Add custom logger

### DIFF
--- a/app/src/main/java/com/yterletskyi/happyfriend/common/logger/Logger.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/common/logger/Logger.kt
@@ -1,0 +1,27 @@
+package com.yterletskyi.happyfriend.common.logger
+
+import android.util.Log
+import com.yterletskyi.happyfriend.BuildConfig
+
+interface Logger {
+    fun info(message: String)
+    fun error(exception: Exception)
+}
+
+class LogcatLogger(
+    private val tag: String,
+    private val enable: Boolean = BuildConfig.DEBUG,
+) : Logger {
+
+    override fun info(message: String) {
+        if (enable) {
+            Log.i(tag, message)
+        }
+    }
+
+    override fun error(exception: Exception) {
+        if (enable) {
+            Log.e(tag, exception.message, exception)
+        }
+    }
+}

--- a/app/src/main/java/com/yterletskyi/happyfriend/common/logger/LoggerX.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/common/logger/LoggerX.kt
@@ -1,6 +1,6 @@
 package com.yterletskyi.happyfriend.common.logger
 
-inline fun <reified C : Any> C.loggers(
+inline fun <reified C : Any> C.logcatLogger(
     noinline tag: () -> String? = { C::class.simpleName }
 ): Lazy<Logger> {
     return lazy {

--- a/app/src/main/java/com/yterletskyi/happyfriend/common/logger/LoggerX.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/common/logger/LoggerX.kt
@@ -1,0 +1,14 @@
+package com.yterletskyi.happyfriend.common.logger
+
+inline fun <reified C : Any> C.loggers(
+    noinline tag: () -> String? = { C::class.simpleName }
+): Lazy<Logger> {
+    return lazy {
+        LogcatLogger(
+            tag = tag()
+                ?: throw IllegalStateException(
+                    "Logging in anonymous classes require non-null tag parameter"
+                )
+        )
+    }
+}

--- a/app/src/main/java/com/yterletskyi/happyfriend/features/contacts/data/FetchBirthdaysOnInitContactsDataSource.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/features/contacts/data/FetchBirthdaysOnInitContactsDataSource.kt
@@ -5,9 +5,10 @@ import android.database.Cursor
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.provider.ContactsContract
-import android.util.Log
 import androidx.core.net.toUri
 import com.yterletskyi.happyfriend.common.BirthdayParser
+import com.yterletskyi.happyfriend.common.logger.Logger
+import com.yterletskyi.happyfriend.common.logger.loggers
 import java.time.LocalDate
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +19,8 @@ class FetchBirthdaysOnInitContactsDataSource @Inject constructor(
     private val initialContactsFlow: MutableStateFlow<List<Contact>>,
     private val birthdayParser: BirthdayParser
 ) : ContactsDataSource {
+
+    private val logger: Logger by loggers()
 
     private var contactBirthdayMap = queryBirthdays()
 
@@ -49,7 +52,7 @@ class FetchBirthdaysOnInitContactsDataSource @Inject constructor(
                 list.add(contact)
             }
         }
-        Log.i("info23", "returned ${list.size} contacts")
+        logger.info("returned ${list.size} contacts")
         initialContactsFlow.value = list
     }
 

--- a/app/src/main/java/com/yterletskyi/happyfriend/features/contacts/data/FetchBirthdaysOnInitContactsDataSource.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/features/contacts/data/FetchBirthdaysOnInitContactsDataSource.kt
@@ -8,7 +8,7 @@ import android.provider.ContactsContract
 import androidx.core.net.toUri
 import com.yterletskyi.happyfriend.common.BirthdayParser
 import com.yterletskyi.happyfriend.common.logger.Logger
-import com.yterletskyi.happyfriend.common.logger.loggers
+import com.yterletskyi.happyfriend.common.logger.logcatLogger
 import java.time.LocalDate
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -20,7 +20,7 @@ class FetchBirthdaysOnInitContactsDataSource @Inject constructor(
     private val birthdayParser: BirthdayParser
 ) : ContactsDataSource {
 
-    private val logger: Logger by loggers()
+    private val logger: Logger by logcatLogger()
 
     private var contactBirthdayMap = queryBirthdays()
 

--- a/app/src/main/java/com/yterletskyi/happyfriend/features/contacts/data/TimeMeasuredContactsDataSource.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/features/contacts/data/TimeMeasuredContactsDataSource.kt
@@ -1,7 +1,7 @@
 package com.yterletskyi.happyfriend.features.contacts.data
 
 import com.yterletskyi.happyfriend.common.logger.Logger
-import com.yterletskyi.happyfriend.common.logger.loggers
+import com.yterletskyi.happyfriend.common.logger.logcatLogger
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
@@ -10,7 +10,7 @@ class TimeMeasuredContactsDataSource(
     private val impl: ContactsDataSource
 ) : ContactsDataSource by impl {
 
-    private val logger: Logger by loggers()
+    private val logger: Logger by logcatLogger()
 
     init {
         logger.info("initializing contacts data source")

--- a/app/src/main/java/com/yterletskyi/happyfriend/features/contacts/data/TimeMeasuredContactsDataSource.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/features/contacts/data/TimeMeasuredContactsDataSource.kt
@@ -1,6 +1,7 @@
 package com.yterletskyi.happyfriend.features.contacts.data
 
-import android.util.Log
+import com.yterletskyi.happyfriend.common.logger.Logger
+import com.yterletskyi.happyfriend.common.logger.loggers
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
@@ -9,13 +10,15 @@ class TimeMeasuredContactsDataSource(
     private val impl: ContactsDataSource
 ) : ContactsDataSource by impl {
 
+    private val logger: Logger by loggers()
+
     init {
-        Log.i("info23", "initializing contacts data source")
+        logger.info("initializing contacts data source")
     }
 
     override fun search(query: String) {
-        Log.i("info23", "searching for <$query>")
+        logger.info("searching for <$query>")
         val time = measureTime { impl.search(query) }
-        Log.i("info23", "getContacts with query=<$query> took <${time.inSeconds}> sec")
+        logger.info("getContacts with query=<$query> took <${time.inSeconds}> sec")
     }
 }

--- a/app/src/main/java/com/yterletskyi/happyfriend/features/ideas/ui/IdeaEditText.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/features/ideas/ui/IdeaEditText.kt
@@ -2,16 +2,19 @@ package com.yterletskyi.happyfriend.features.ideas.ui
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.Log
 import android.view.KeyEvent
 import android.view.View.OnFocusChangeListener
 import androidx.appcompat.widget.AppCompatEditText
+import com.yterletskyi.happyfriend.common.logger.Logger
+import com.yterletskyi.happyfriend.common.logger.loggers
 import com.yterletskyi.happyfriend.common.x.setTextNoTextWatcher
 
 class IdeaEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
 ) : AppCompatEditText(context, attrs) {
+
+    private val logger: Logger by loggers()
 
     var onNewIdeaRequested: ((String) -> Unit)? = null
     var onRemoveIdeaRequested: (() -> Unit)? = null
@@ -23,7 +26,7 @@ class IdeaEditText @JvmOverloads constructor(
     }
 
     private fun onNewLineAdded(before: CharSequence, after: CharSequence) {
-        Log.i("info24", "before: [$before] - after: [$after]")
+        logger.info("before: [$before] - after: [$after]")
         setTextNoTextWatcher(newLineWatcher, before)
         onNewIdeaRequested?.invoke(after.toString())
     }
@@ -31,7 +34,7 @@ class IdeaEditText @JvmOverloads constructor(
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
         if (keyCode == KeyEvent.KEYCODE_DEL) {
             if (text?.isEmpty() == true) {
-                Log.i("info24", "backspace clicked on empty idea")
+                logger.info("backspace clicked on empty idea")
                 onRemoveIdeaRequested?.invoke()
             }
             return true

--- a/app/src/main/java/com/yterletskyi/happyfriend/features/ideas/ui/IdeaEditText.kt
+++ b/app/src/main/java/com/yterletskyi/happyfriend/features/ideas/ui/IdeaEditText.kt
@@ -6,7 +6,7 @@ import android.view.KeyEvent
 import android.view.View.OnFocusChangeListener
 import androidx.appcompat.widget.AppCompatEditText
 import com.yterletskyi.happyfriend.common.logger.Logger
-import com.yterletskyi.happyfriend.common.logger.loggers
+import com.yterletskyi.happyfriend.common.logger.logcatLogger
 import com.yterletskyi.happyfriend.common.x.setTextNoTextWatcher
 
 class IdeaEditText @JvmOverloads constructor(
@@ -14,7 +14,7 @@ class IdeaEditText @JvmOverloads constructor(
     attrs: AttributeSet? = null,
 ) : AppCompatEditText(context, attrs) {
 
-    private val logger: Logger by loggers()
+    private val logger: Logger by logcatLogger()
 
     var onNewIdeaRequested: ((String) -> Unit)? = null
     var onRemoveIdeaRequested: (() -> Unit)? = null


### PR DESCRIPTION
A custom logger added - `LogcatLogger` (`Logger`) which is more convenient to use.
The usage is simple:
- create the logger in a needed class: `private val logger: Logger by logcatLogger()`
By default it will take the _invoker class name_ as a _tag_ and will be enabled in _DEBUG_ build type.

The logger will not be logging in release builds.